### PR TITLE
Fix error signaling when executing fetch request

### DIFF
--- a/036-searching-in-uitableview/SearchStore/SearchStore/MasterViewController.m
+++ b/036-searching-in-uitableview/SearchStore/SearchStore/MasterViewController.m
@@ -71,7 +71,7 @@
     
     NSError *error = nil;
     NSArray *results = [[self managedObjectContext] executeFetchRequest:fetchRequest error:&error];
-    if (error) {
+    if (results == nil) {
         [NSException raise:NSGenericException format:@"Error filtering for term: %@ -- %@", term, error];
     }
     


### PR DESCRIPTION
`-[NSManagedObjectContext executeFetchRequest:error:]` does not necessarily signal an error/non-error result based on the non-nil/nil state of the `NSError` pointer. According to the `NSManagedObjectContext` documentation, the return value of `executeFetchRequest:error:` is:

> An array of objects that meet the criteria specified by request fetched from the receiver and from the persistent stores associated with the receiver’s persistent store coordinator. **If an error occurs, returns nil.** If no objects match the criteria specified by request, returns an empty array.

(emphasis mine, via [`executeFetchRequest:error:` docs](https://developer.apple.com/library/mac/#documentation/Cocoa/Reference/CoreDataFramework/Classes/NSManagedObjectContext_Class/NSManagedObjectContext.html))

Yes, this is clunky and unexpected, but it's the conventional use of `NSError` for error signaling. See the _Handling Error Objects Returned from Methods_ section of Apple's _Error Handling Programming Guide_, specifically:

> **Important**: Success or failure is indicated by the return value of the method. Although Cocoa methods that indirectly return error objects in the Cocoa error domain are guaranteed to return such objects if the method indicates failure by directly returning nil or NO, you should always check that the return value is nil or NO before attempting to do anything with the NSError object.

(via Apple's [Error Handling Programming Guide](http://developer.apple.com/library/ios/#DOCUMENTATION/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html)).
