### PR TITLE
Fix bug where subsequent refresh duplicates data

### DIFF
--- a/012-core-data-importing-data/BeerBrowser/BeerBrowser/MasterViewController.m
+++ b/012-core-data-importing-data/BeerBrowser/BeerBrowser/MasterViewController.m
@@ -124,6 +124,7 @@
             Brewery *brewery = [Brewery breweryWithServerId:serverId usingManagedObjectContext:context];
             if (brewery == nil) {
                 brewery = [Brewery insertInManagedObjectContext:context];
+                [brewery setServerId:[NSNumber numberWithInteger:serverId]];
             }
             
             [brewery updateAttributes:dictionary];


### PR DESCRIPTION
Since serverId is never set, the lookup always returns nil. This fixes that and sets the id on insert.
