### PR TITLE
047-gesture-recognizers. Solving the swipe down problem in another way.

### DIFF
--- a/047-gesture-recognizers/PhotoTable/PhotoTable/ViewController.m
+++ b/047-gesture-recognizers/PhotoTable/PhotoTable/ViewController.m
@@ -140,19 +140,11 @@
     [rotation setRotation:0];
 }
 
-- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    if ([gestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]]) {
-        CGPoint touchPoint = [gestureRecognizer locationInView:self.view];
-        UIView *hitTestView = [self.view hitTest:touchPoint withEvent:nil];
-        if ([hitTestView isKindOfClass:[UIImageView class]]) {
-            return NO;
-        }
-    }
-    
-    return YES;
-}
-
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if ([gestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]] ||
+        [otherGestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]]) {
+        return NO;
+    }
     return YES;
 }
 


### PR DESCRIPTION
In the episode 47 you mention that the

```
  - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer 
```

doesn't solve the swipe down problem.

You try this code:

```
- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
if ([gestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]]) {
    return NO;
}
return YES;}
```

Yes, this doesn't work. But there is a simple way to fix that. The reason is that the gesture that come in the first parameter is the pan gesture, because is the first that is detected. But then you can check if the otherGestureRecognizer is the swipe:

```
- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
if ([gestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]] ||
    [otherGestureRecognizer isKindOfClass:[UISwipeGestureRecognizer class]]) {
    return NO;
}
return YES;}
```

;)
