### PR TITLE
Call layoutIfNeeded in order to trigger autolayout

### DIFF
--- a/172-magic-move/MagicMove/MagicMove/Animator.swift
+++ b/172-magic-move/MagicMove/MagicMove/Animator.swift
@@ -36,6 +36,8 @@ class Animator: NSObject, UIViewControllerAnimatedTransitioning {
         let toVC = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey)! as! DetailViewController
         let container = transitionContext.containerView()
         
+        toVC.view.layoutIfNeeded()
+        
         let fromImageView = getCellImageView(fromVC)
         let toImageView = toVC.imageView
         


### PR DESCRIPTION
If layoutIfNeeded is not called, the toVC subviews' frames are the ones defined on storyboard and not the final ones.