### PR TITLE
Fix build errors for 175 sample

### DIFF
--- a/175-nsoperation-basics/OperationBasics/OperationBasics/FreeSpaceOperation.swift
+++ b/175-nsoperation-basics/OperationBasics/OperationBasics/FreeSpaceOperation.swift
@@ -21,22 +21,26 @@ class FreeSpaceOperation : NSOperation {
     override func main() {
         let fileManager = NSFileManager.defaultManager()
         
-        for i in reverse(1...5) {
+        for i in (1...5).reverse() {
             if cancelled {
                 return
             }
-
-            println("Sleeping \(i)...")
+            
+            print("Sleeping \(i)...")
             sleep(1)
         }
         
         if cancelled {
             return
         }
-        
-        let attribs = fileManager.attributesOfFileSystemForPath(path, error: &error)
-        println("attribs for \(path): \(attribs)")
-        
-        self.fileSystemAttributes = attribs
+
+        do {
+            let attribs = try fileManager.attributesOfFileSystemForPath(path)
+            print("attribs for \(path): \(attribs)")
+            
+            self.fileSystemAttributes = attribs
+        } catch {
+            print(error)
+        }
     }
 }


### PR DESCRIPTION
This pr fixes Swift 2 related build errors in the 175 sample involving `reverse`, `print` and error handling.