### PR TITLE
using EpisodeResponse init and letting flatMap

### DIFF
--- a/238-core-data-in-ios10/CoreData10/CoreData10/APIClient.swift
+++ b/238-core-data-in-ios10/CoreData10/CoreData10/APIClient.swift
@@ -33,7 +33,7 @@ class APIClient {
                 if let json = try? JSONSerialization.jsonObject(with: data!, options: []) as? JSONDictionary,
                     let episodesJSON = json?["episodes"] as? [JSONDictionary] {
 
-                    let episodes = episodesJSON.map(EpisodeResponse.init).flatMap { $0! }
+                    let episodes = episodesJSON.flatMap(EpisodeResponse.init)
                     DispatchQueue.main.async {
                         completion(.success(episodes))
                     }


### PR DESCRIPTION
the EpisodeResponse init expect only one parameter, corresponding to the $0, so we can avoid using map and let flatMap show it's power ;)
Great episode, by the way, congrats!